### PR TITLE
Update seminar page with embedded Google calendar.

### DIFF
--- a/seminar.md
+++ b/seminar.md
@@ -3,29 +3,9 @@ layout: page
 title: Lunch Seminar
 permalink: /seminar/
 ---
+Princeton SNS hosts a weekly lunch seminar, which we use to present recent work and discuss interesting papers.
+Refer to the calendar below to see our upcoming meetings. We also occasionally host talks from researchers from outside the group,
+both from industry and academia. If you're interested in giving a talk, please
+<a href="mailto:jhelt+sns-seminar@cs.princeton.edu">send us an email</a>. 
 
-{% capture now %}
-{{'now' | date: '%s' | plus: 0 %}}
-{% endcapture %}
-
-{:.schedule}
-{%- for seminar in site.data.seminars -%}
-
-{% capture date %}
-{{seminar.date | date: '%s' | plus: 0 %}}
-{% endcapture %}
-{% if date > now %}
-{% if seminar.speaker %}
-{%- assign author = seminar.speaker -%}
-1. <span class="date">{{ seminar.date | date: "%B %-d, %Y" }}</span>
-   <span class="title">{{ seminar.title }}</span>  
-
-   <span class="speaker">**Speaker: {% include name.html %}**</span>
-   **Abstract**: {{ seminar.abstract }}
-{% else %}
-1. {:.nospeaker}
-   <span class="date">{{ seminar.date | date: "%B %-d, %Y" }}</span>
-   <span class="title">No speaker: {{ seminar.reason }}</span>
-{% endif %}
-{% endif %}
-{% endfor %}
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FNew_York&amp;src=bWtyMzNjNWU0dW80YzdsdmN1dDRmMTY5cG9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23F09300&amp;title=Calendar" style="border-width:0" width="780" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
Maintaining a static version of the seminar page seemed like a pain, so I updated the seminar page to include an embedded iframe with the systems lunch Google calendar. Screenshot below. Thoughts?

<img width="792" alt="Screen Shot 2019-06-29 at 4 36 20 PM" src="https://user-images.githubusercontent.com/16727193/60389237-598ca800-9a8c-11e9-85d7-ef10bd2ed7dc.png">
