### PR TITLE
Add postdocs and alumni.

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -56,6 +56,16 @@
     url: https://aaron.blankstein.com/
     picture: /assets/img/people/ablankst.jpg
 
+  - first_name: Haoyu (Harris)
+    last_name: Zhang
+    nick: hzhang
+    type: phd
+    active: false
+    graduated: 2018
+    now: Google Brain
+    url: https://haoyuzhang.org/
+    picture: /assets/img/people/placeholder.jpg
+
   - first_name: Amy
     last_name: Tai
     nick: amytai
@@ -63,7 +73,7 @@
     active: false
     graduated: 2018
     now: VMWare Research
-    url: http://www.cs.princeton.edu/~amytai/
+    url: https://amytai.github.io/
     picture: /assets/img/people/amytai.jpg
 
   - first_name: Andrew
@@ -93,8 +103,8 @@
   - first_name: Haonan
     last_name: Lu
     nick: haonanl
-    type: phd
-    active: false
+    type: postdoc
+    active: true
     url: http://www.cs.princeton.edu/~haonanl/
     picture: /assets/img/people/placeholder.png
 
@@ -135,6 +145,7 @@
     nick: melara
     type: phd
     active: false
+    graduated: 2019
     url: http://masomel.info
     picture: /assets/img/people/melara.jpg
 
@@ -151,7 +162,8 @@
     nick: stafman
     type: phd
     active: false
-    url: http://www.cs.princeton.edu/~stafman/
+    graduated: 2019
+    url: http://stafman.com/
     picture: /assets/img/people/stafman.jpg
 
   - first_name: Theano
@@ -193,7 +205,7 @@
     active: false
     graduated: 2013
     now: Microsoft Research
-    url: http://www.cs.princeton.edu/~sssix
+    url: http://sidsen.azurewebsites.net/
     picture: /assets/img/people/sssix.png
 
   - first_name: Natalie
@@ -218,5 +230,65 @@
     type: phd
     active: true
     url: https://www.cs.princeton.edu/~jiananl/
+    picture: /assets/img/people/placeholder.png
+
+  - first_name: Jeff
+    last_name: Terrace
+    nick: jterrace
+    type: phd
+    active: false
+    graduated: 2012
+    now: Google
+    url: http://jeffterrace.com/
+    picture: /assets/img/people/placeholder.png
+
+  - first_name: David
+    last_name: Shue
+    nick: dshue
+    type: phd
+    active: false
+    graduated: 2014
+    now: Google
+    url: https://www.linkedin.com/in/david-shue-65686b66
+    picture: /assets/img/people/placeholder.png
+
+  - first_name: Prem
+    last_name: Gopalam
+    nick: pgopalam
+    type: phd
+    active: false
+    graduated: 2014
+    now: Voleon Capital Management
+    url: 
+    picture: /assets/img/people/placeholder.png
+
+  - first_name: Rob
+    last_name: Kiefer
+    nick: rkiefer
+    type: phd
+    active: false
+    graduated: 2016
+    now: Timescale
+    url: 
+    picture: /assets/img/people/placeholder.png
+
+  - first_name: Xiaozhou
+    last_name: Li
+    nick: xli
+    type: phd
+    active: false
+    graduated: 2016
+    now: Celer Network
+    url: https://www.xiaozhouli.org/
+    picture: /assets/img/people/placeholder.png
+
+  - first_name: Matvey
+    last_name: Arye
+    nick: marye
+    type: phd
+    active: false
+    graduated: 2016
+    now: Timescale
+    url: https://www.linkedin.com/in/matvey-arye-70a270b5
     picture: /assets/img/people/placeholder.png
 

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -161,37 +161,48 @@ body > main, body > article {
 ul.people {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(30%,1fr));
+
   li {
     display: grid;
+    text-align: left;
+
     grid-template-rows: auto;
-    grid-template-columns: auto;
-    width: fit-content;
+    grid-template-columns: 6em auto;
+    grid-template-areas: "img name" ". .";
+
+    margin: 1em 0;
+
     p {
-      display: grid;
-      text-align: center;
-      > * {
-        display: block;
-      }
+        display: grid;
+        grid-area: 1 / 1 / -1 / -1;
+
+        grid-template-rows: auto;
+        grid-template-columns: 6em auto;
+        grid-template-areas: "img name" ". .";
+
+        margin: 0;
     }
 
-    p:first-of-type {
-      text-align: left;
-      grid-template-columns: 6em auto;
-      grid-template-areas: "img name" ". .";
-      img {
+    img {
         grid-area: img;
         vertical-align: middle;
-	height: 5em;
+        height: 5em;
         border-radius: 100%;
         margin-right: 1em;
-      }
-      a {
+    }
+
+    a {
         grid-area: name;
         line-height: 1em;
-	margin: auto 0;
-      }
+        margin: auto 0;
     }
   }
+}
+
+ul.past-members {
+    columns: 3;
+    -webkit-columns: 3;
+    -moz-columns: 3;
 }
 
 // Publications are structured like so:

--- a/home.md
+++ b/home.md
@@ -10,14 +10,22 @@ Service-centric, Storage-based — characterizes the broad scope of our research
 
 
 {%- assign leaders = site.data.people | where: "type", "leader" | where: "active", "true" | sort: "last_name" %}
+{%- assign postdocs = site.data.people | where: "type", "postdoc" | where: "active", "true" | sort: "last_name" %}
 {%- assign phds = site.data.people | where: "type", "phd" | where: "active", "true" | sort: "last_name" %}
 {%- assign mscs = site.data.people | where: "type", "msc" | where: "active", "true" | sort: "last_name" %}
-{%- assign past = site.data.people | where: "active", "false" | sort: "last_name" %}
+{%- assign past = site.data.people | where: "active", "false" | sort: "graduated" | reverse %}
 
 ### Faculty
 
 {:.people}
   {%- for person in leaders %}
+  * ![]({{person.picture}}) [{{person.first_name}} {{person.last_name}}]({{person.url}})
+  {% endfor %}
+
+### Postdocs
+
+{:.people}
+  {%- for person in postdocs %}
   * ![]({{person.picture}}) [{{person.first_name}} {{person.last_name}}]({{person.url}})
   {% endfor %}
 
@@ -37,7 +45,8 @@ Service-centric, Storage-based — characterizes the broad scope of our research
 
 ### Past Members
 
+{:.past-members}
 {%- for person in past %}
-* [{{person.first_name}} {{person.last_name}}]({{person.url}}) ({{person.type}})  
+* [{{person.first_name}} {{person.last_name}}]({{person.url}})
 {%- endfor -%}
 


### PR DESCRIPTION
Add postdocs and alumni. The changes to the CSS are necessary to make our grid work when there is only one member in a group (e.g., postdocs currently). The generated HTML in this case omits a paragraph element around the images and names, so the old styles didn't work.

This is a simpler/better solution than moving to bootstrap, as in #3.