### PR TITLE
Update Haonan's status as Prof. U. Buffalo

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -105,8 +105,10 @@
     last_name: Lu
     nick: haonanl
     type: postdoc
-    active: true
-    url: http://www.cs.princeton.edu/~haonanl/
+    active: false
+    graduated: 2022
+    now: Assistant Professor at University at Buffalo
+    url: https://sites.google.com/view/haonanlu/home
     picture: /assets/img/people/placeholder.png
 
   - first_name: David H.


### PR DESCRIPTION
Haonan finished post-doc and is now an prof at University of Buffalo

@wlloyd or @haonanlu  confirm details?

```yaml
    graduated: 2022
    now: Assistant Professor at University at Buffalo
    url: https://sites.google.com/view/haonanlu/home
```